### PR TITLE
Fix camera calibration

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -691,11 +691,12 @@ class MonoCalibrator(Calibrator):
         # If FIX_ASPECT_RATIO flag set, enforce focal lengths have 1/1 ratio
         self.intrinsics[0,0] = 1.0
         self.intrinsics[1,1] = 1.0
-        cv2.calibrateCamera(
-                   opts, ipts,
-                   self.size, self.intrinsics,
-                   self.distortion,
-                   flags = self.calib_flags)
+
+
+        ret, self.intrinsics, self.distortion, rvecs, tvecs = cv2.calibrateCamera(
+            opts, ipts, self.size, None, None, flags = self.calib_flags)
+
+        self.distortion = np.reshape(self.distortion, (np.prod(self.distortion.shape), -1)) # (d, 1)
 
         aspect = self.size[1]/float(self.size[0])
         iw = 500

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -138,8 +138,6 @@ class CalibrationNode(Node):
         sth.setDaemon(True)
         sth.start()
 
-        self.handle_monocular_time = time.time()
-
     def redraw_stereo(self, *args):
         pass
     def redraw_monocular(self, *args):
@@ -153,8 +151,6 @@ class CalibrationNode(Node):
 
     def handle_monocular(self, msg):
         
-        print(f"Processing image: dt={time.time() - self.handle_monocular_time:.2f}", flush=True)
-        self.handle_monocular_time = time.time()
         if self.c == None:
             if self._camera_name:
                 self.c = MonoCalibrator(self._boards, self._calib_flags, self._pattern, name=self._camera_name,


### PR DESCRIPTION

## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

[Jira ticket](https://tier4.atlassian.net/browse/T4PB-14901)
[Data to validate the fix](https://drive.google.com/drive/folders/1RhuzOpYTtTXqDlftjxu6Rb-I6b1iWrv-?usp=sharing)
<!-- Please write related links to GitHub/Jira/Slack/etc. -->


## Description
After a commit introducing coverage and error plots among other changes such as the QoS and blob detector parameters, the calibrator got broken.
This PR fixes these by doing the following:

- Updates drawing CV methods that changed their signature. In particular, it became necessary to pass some arguments as int.
- Drawing methods are deferred to the main thread, which handles ALL UI related interactions. This is due to these methods not being thread safe, which caused deadlocks-like phenomena.
- Instead of locks to assure thread safety, we use the same method used in the original code, which are thread-safe structure from `collections`.
- Replaces the way the calibrator threads handle data. They were processing the same old data multiple times. Now they only handle it once, which decreases the CPU usage considerably (non critical)

**As a comment, the newest non-broken branch had a better detection rate of the calibration boards. This is due to the fact that custom parameters were added in the base branch. I kept the new parameters, since this may have been added on pourpose for robustness** 

<!-- Describe what this PR changes. -->



## Review Procedure

1. Check that the base branch does not work
2. Download the data previously mentioned.
3. Run the bag with `ros2 bag play camera_calibration_minimal/ -l -r 10.0 --read-ahead-queue-size 100
`
4. Run the camera calibrator with `ros2 run camera_calibration cameracalibrator --no-service-check --camera_name camera --size 8x6 --square 0.120 --pattern circles`
5. The coverage should be over 70% in less than a minute
6. The calibration should be along the lines of:

```
[image]

width
1440

height
1080

[camera]

camera matrix
1217.149139 0.000000 756.560558
0.000000 1223.925358 526.302117
0.000000 0.000000 1.000000

distortion
-0.081791 0.106776 -0.007570 0.010567 0.000000

rectification
1.000000 0.000000 0.000000
0.000000 1.000000 0.000000
0.000000 0.000000 1.000000

projection
1205.631104 0.000000 770.683706 0.000000
0.000000 1219.071777 517.822282 0.000000
0.000000 0.000000 1.000000 0.000000

```

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [pull request guidelines][pull-request-guidelines]
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/KB4FAE/pages/1748435052
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute