### PR TITLE
Fix the circle pattern board when it is vertically oriented

### DIFF
--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -247,9 +247,9 @@ def _get_circles(img, board, pattern):
             mono_arr, (board.n_rows, board.n_cols), flags=flag, blobDetector=detector)
 
         if ok:
-            corners = corners.reshape((board.n_cols, board.n_rows, 2))
-            corners = np.transpose(corners, (1, 0, 2))
-            corners = corners.reshape(-1, 1, 2)
+            corners_2d_array = corners.reshape((board.n_cols, board.n_rows, 2))
+            corners_transposed = np.transpose(corners_2d_array, (1, 0, 2))
+            corners = corners_transposed.reshape(-1, 1, 2)
 
     if ok:
         # Re-scaling results

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -246,6 +246,7 @@ def _get_circles(img, board, pattern):
         (ok, corners) = cv2.findCirclesGrid(
             mono_arr, (board.n_rows, board.n_cols), flags=flag, blobDetector=detector)
 
+        # We need to swap the axes of the detections back to make it consistent
         if ok:
             corners_2d_array = corners.reshape((board.n_cols, board.n_rows, 2))
             corners_transposed = np.transpose(corners_2d_array, (1, 0, 2))

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -246,6 +246,11 @@ def _get_circles(img, board, pattern):
         (ok, corners) = cv2.findCirclesGrid(
             mono_arr, (board.n_rows, board.n_cols), flags=flag, blobDetector=detector)
 
+        if ok:
+            corners = corners.reshape((board.n_cols, board.n_rows, 2))
+            corners = np.transpose(corners, (1, 0, 2))
+            corners = corners.reshape(-1, 1, 2)
+
     if ok:
         # Re-scaling results
         corners = corners * (1. / scale )


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

[Jira ticket](https://tier4.atlassian.net/browse/T4PB-17397)
[Data to validate the fix](https://drive.google.com/drive/folders/1OyZH9JXDXd5ooza7unLdy7WjKDyZiZE_?usp=sharing)
<!-- Please write related links to GitHub/Jira/Slack/etc. -->


## Description
The circle pattern detector has to be run twice depending on the orientation of the board.
However, when the board was detected vertically, the points where not in the order the rest of the code expected causing a completely wrong camera calibration result.

For example, the focal distance should be around 1000 px, but the estimation could be from 3.000 px to 10.000 px

<!-- Describe what this PR changes. -->



## Review Procedure

1. Perform camera calibration without this PR and the provided data and confirm the previously stated error.
2. Using the PR validate that the calibration provides correct camera intrinsics
<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [pull request guidelines][pull-request-guidelines]
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[clang-tidy-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/ClangTidyGuideline/
[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[pull-request-guidelines]: https://tier4.github.io/autoware.proj/tree/main/developer_guide/PullRequestGuideline/
[release-notes]: https://tier4.atlassian.net/wiki/spaces/KB4FAE/pages/1748435052
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute